### PR TITLE
added body to req.body to be compatible with proxies

### DIFF
--- a/lib/framework/middleware.js
+++ b/lib/framework/middleware.js
@@ -333,7 +333,14 @@ function raw(ctx) {
         if (err.statusCode) return res.sf.reply(err);
         return next(err);
       }
+
       req.sf.text = text;
+
+      // Mimic body-parser for use by proxies
+      if (text && text.length) {
+        req.body = text;
+      }
+
       next();
     });
   };


### PR DESCRIPTION
proxies and swagger-framework/body-parser both consume the `req` stream which can only be read once. if swagger-framework puts the req contents into `req.body` then the proxy can look for req.body if req has already been consumed and use that instead.