### PR TITLE
overwriting `content-length` and `content-type` if it doesnt match

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -114,11 +114,13 @@ function reply(req, res, opts) {
     var noContent = statusCode === 204 || statusCode === 304;
 
     if (!noContent && !res.headersSent) {
-      if (type && !res.getHeader('content-type')) {
+      if (type && !res.getHeader('content-type') ||
+        res.getHeader('content-type') !== type) {
         res.setHeader('content-type', type + '; charset=' + CHARSET);
       }
 
-      if (!res.getHeader('content-length')) {
+      if (!res.getHeader('content-length') ||
+        res.getHeader('content-length') !== length) {
         res.setHeader('content-length', length);
       }
 

--- a/test/http.js
+++ b/test/http.js
@@ -127,5 +127,27 @@ describe('index', function() {
         done();
       });
     });
+
+    it('should overwrite content-length if doesnt match', function(done) {
+      var self = this;
+      var length = JSON.stringify(self.body).length;
+      var expectedType = 'application/json; charset=utf8';
+
+      // Simulate a proxied request with a different response type and length
+      self.res.setHeader('content-type', 'text/html');
+      self.res.setHeader('content-length', 2);
+      self.res._headers.should.have.property('content-length');
+      self.res._headers['content-length'].should.eql(2);
+
+      self.run(function() {
+        self.res._headers.should.have.property('content-length');
+        self.res._headers['content-length'].should.eql(length);
+
+        self.res._headers.should.have.property('content-type');
+        self.res._headers['content-type'].should.eql(expectedType);
+
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
support for proxied responses which are set from original response, but overwritten/standardized by swagger-framework

Example use case: 

original response from a proxied request might be `text/html` and a certain length:
```
Unauthorized
```

response wrapped in to a `application/json` response, with a new length:
```
{ message: 'Unauthorized' }
```